### PR TITLE
fix: invalid expand path

### DIFF
--- a/src/utils/VisibleNodesGenerator.ts
+++ b/src/utils/VisibleNodesGenerator.ts
@@ -287,22 +287,15 @@ class FlattenLayer extends CompressLayer {
     const rootNode = this.compressedRoot
     if (rootNode) {
       await traverse(
-        [rootNode],
+        rootNode.contents,
         async node => {
-          const overflowChar = node.path[path.length + 1]
-          const nextChar = path.slice(node.path.length, node.path.length + 1) 
-          const match =
-            path.startsWith(node.path) &&
-            (overflowChar === '/' || !overflowChar) &&
-            (!node.path || nextChar === '/' || !nextChar)
-          if (node.path) {
-            // rootNode.path === ''
-            if (match) {
-              if (node.path === path) {
-                // do not wait for expansion for the exact node as that will block "jumping from search"
-                this.$setExpand(node, true)
-              } else await this.$setExpand(node, true)
-            }
+          const overflowChar = path[node.path.length]
+          const match = path.startsWith(node.path) && (overflowChar === '/' || !overflowChar)
+          if (match) {
+            if (node.path === path) {
+              // do not wait for expansion for the exact node as that will block "jumping from search"
+              this.$setExpand(node, true)
+            } else await this.$setExpand(node, true)
           }
           return match
         },

--- a/src/utils/VisibleNodesGenerator.ts
+++ b/src/utils/VisibleNodesGenerator.ts
@@ -290,7 +290,11 @@ class FlattenLayer extends CompressLayer {
         [rootNode],
         async node => {
           const overflowChar = node.path[path.length + 1]
-          const match = path.startsWith(node.path) && (overflowChar === '/' || !overflowChar)
+          const nextChar = path.slice(node.path.length, node.path.length + 1) 
+          const match =
+            path.startsWith(node.path) &&
+            (overflowChar === '/' || !overflowChar) &&
+            (!node.path || nextChar === '/' || !nextChar)
           if (node.path) {
             // rootNode.path === ''
             if (match) {


### PR DESCRIPTION
TestCase: <https://github.com/go-kit/kit/blob/3796a6b25f/sd/etcdv3/client.go>

Path: `sd/etcdv3/client.go`
NodePath: `sd/etcdv3` and `sd/etcd` will  be both expanded.