### PR TITLE
Add support for using § key on Mac keyboards for sidebar toggle shortcut

### DIFF
--- a/src/utils/keyHelper.ts
+++ b/src/utils/keyHelper.ts
@@ -1,5 +1,5 @@
 const keyCodeArray = [
-  ...'1234567890abcdefghijklmnopqrstuvwxyz'.split(''),
+  ...'1234567890abcdefghijklmnopqrstuvwxyz§'.split(''),
   ..."`[]\\;',./".split(''),
   'alt',
   'shift',

--- a/src/utils/keyHelper.ts
+++ b/src/utils/keyHelper.ts
@@ -1,6 +1,9 @@
 const keyCodeArray = [
-  ...'1234567890abcdefghijklmnopqrstuvwxyz§'.split(''),
-  ..."`[]\\;',./".split(''),
+  ...'1234567890abcdefghijklmnopqrstuvwxyz'.split(''),
+  /* the key that's located left to the 1 key in Mac
+     keybords in multiple Engligh laybouts (Backquote) */
+  ...'`§'.split(''),
+  ..."[]\\;',./".split(''),
   'alt',
   'shift',
   'ctrl',


### PR DESCRIPTION
This allows reusing the `§` key on Mac keyboards (`§` key is located left to the `1` button)