### PR TITLE
Use "window.location.protocol" instead of hardcoded "https".

### DIFF
--- a/src/platforms/Gitea/API.ts
+++ b/src/platforms/Gitea/API.ts
@@ -57,14 +57,14 @@ async function request(
   }
 }
 
-export const API_ENDPOINT = `${window.location.host}/api/v1`
+export const API_ENDPOINT = `${window.location.protocol}//${window.location.host}/api/v1`
 
 export async function getRepoMeta(
   userName: string,
   repoName: string,
   accessToken?: string,
 ): Promise<GiteaAPI.MetaData> {
-  const url = `https://${API_ENDPOINT}/repos/${userName}/${repoName}`
+  const url = `${API_ENDPOINT}/repos/${userName}/${repoName}`
   return await request(url, { accessToken })
 }
 
@@ -78,7 +78,7 @@ export async function getTreeData(
   const search = new URLSearchParams()
   if (recursive) search.set('recursive', '1')
   const url =
-    `https://${API_ENDPOINT}/repos/${userName}/${repoName}/git/trees/${branchName}?` + search
+    `${API_ENDPOINT}/repos/${userName}/${repoName}/git/trees/${branchName}?` + search
   return await request(url, { accessToken })
 }
 
@@ -88,7 +88,7 @@ export async function getBlobData(
   sha: string,
   accessToken?: string,
 ): Promise<GitHubAPI.BlobData> {
-  const url = `https://${API_ENDPOINT}/repos/${userName}/${repoName}/git/blobs/${sha}`
+  const url = `${API_ENDPOINT}/repos/${userName}/${repoName}/git/blobs/${sha}`
   return await request(url, { accessToken })
 }
 

--- a/src/platforms/Gitea/index.ts
+++ b/src/platforms/Gitea/index.ts
@@ -65,7 +65,7 @@ function getUrlForRedirect(
   // Modern browsers have great support for handling unsafe URL,
   // It may be possible to sanitize path with
   // `path => path.includes('#') ? path.replace(/#/g, '%23') : '...'
-  return `https://${
+  return `${window.location.protocol}//${
     window.location.host
   }/${userName}/${repoName}/src/branch/${branchName}/${path
     .split('/')
@@ -107,8 +107,8 @@ export const Gitea: Platform = {
   },
   resolveUrlFromMetaData({ userName, repoName }) {
     return {
-      repoUrl: `https://${window.location.host}/${userName}/${repoName}`,
-      userUrl: `https://${window.location.host}/${userName}`,
+      repoUrl: `${window.location.protocol}//${window.location.host}/${userName}/${repoName}`,
+      userUrl: `${window.location.protocol}//${window.location.host}/${userName}`,
     }
   },
   async getTreeData(metaData, path, recursive, accessToken) {
@@ -163,6 +163,6 @@ export const Gitea: Platform = {
     return API.OAuth(code)
   },
   getOAuthLink() {
-    return `https://${window.location.host}/api/v1/user/applications/oauth2`
+    return `${window.location.protocol}//${window.location.host}/api/v1/user/applications/oauth2`
   },
 }


### PR DESCRIPTION
Gitea may be deployed on local server and use http protocol.