### PR TITLE
Use GitHub native PJAX

### DIFF
--- a/src/components/MetaBar.tsx
+++ b/src/components/MetaBar.tsx
@@ -1,6 +1,6 @@
 import { BranchName, Breadcrumb, Flex, Text } from '@primer/components'
 import { GitBranchIcon } from '@primer/octicons-react'
-import { platform } from 'platforms'
+import { platform, platformName } from 'platforms'
 import * as React from 'react'
 import { isOpenInNewWindowClick } from 'utils/general'
 import { loadWithPJAX } from 'utils/hooks/usePJAX'
@@ -28,12 +28,16 @@ export function MetaBar({ metaData }: Props) {
           href={branchUrl}
           as="a"
           className={'branch-name'}
-          onClick={e => {
-            if (isOpenInNewWindowClick(e)) return
+          {...(platformName === 'GitHub'
+            ? { 'data-pjax': '#repo-content-pjax-container' }
+            : {
+                onClick: e => {
+                  if (isOpenInNewWindowClick(e)) return
 
-            e.preventDefault()
-            loadWithPJAX(branchUrl)
-          }}
+                  e.preventDefault()
+                  loadWithPJAX(branchUrl)
+                },
+              })}
         >
           {branchName || '...'}
         </BranchName>

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -1,4 +1,5 @@
 import { useConfigs } from 'containers/ConfigsContext'
+import { platformName } from 'platforms'
 import * as React from 'react'
 import { cx } from 'utils/cx'
 import { isOpenInNewWindowClick } from 'utils/general'
@@ -42,11 +43,15 @@ export function Node({
   return (
     <a
       href={node.url}
-      onClick={event => {
-        if (isOpenInNewWindowClick(event)) return
+      {...(platformName === 'GitHub' && node.type === 'blob'
+        ? { 'data-pjax': '#repo-content-pjax-container' }
+        : {
+            onClick: event => {
+              if (isOpenInNewWindowClick(event)) return
 
-        onClick(event, node)
-      }}
+              onClick(event, node)
+            },
+          })}
       className={cx(`node-item`, { focused, disabled: node.accessDenied, expanded, compact })}
       style={{ ...style, paddingLeft: `${10 + (compact ? 10 : 20) * depth}px` }}
       title={node.path}


### PR DESCRIPTION
GitHub uses `data-pjax` attribute for determining whether a link should be loaded via PJAX. We can utilize it to avoid issues like #173 or compatibility issues with other plugins, instead of rolling our own implementation via `pjax-api` package.

The changes are a little bit messy but making the code reusable seems to be too much a hassle. You can always refactor it to your liking if you want.

Fix #173