### PR TITLE
fix: fix body indent failure when navigating

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -221,7 +221,8 @@ $minimal-z-index: max(
   }
 }
 
-.with-gitako-spacing {
+.with-gitako-spacing,
+body[data-with-gitako-spacing='true'] {
   @media screen {
     margin-left: var(--gitako-width);
   }

--- a/src/utils/DOMHelper.ts
+++ b/src/utils/DOMHelper.ts
@@ -28,6 +28,7 @@ export function markGitakoSafariFlag(enable = true) {
  */
 export const bodySpacingClassName = 'with-gitako-spacing'
 export function setBodyIndent(shouldShowGitako: boolean) {
+  document.body.dataset.withGitakoSpacing = shouldShowGitako ? 'true' : 'false'
   if (shouldShowGitako) {
     document.body.classList.add(bodySpacingClassName)
   } else {
@@ -172,7 +173,7 @@ export function persistGitakoElements(SideBarElement: HTMLElement, logoElement: 
           const oldValue = removedBody.style.getPropertyValue(property)
           if (oldValue) addedBody.style.setProperty(property, oldValue)
         }
-        const cssClassesNeedToMigrate = ['with-gitako-spacing']
+        const cssClassesNeedToMigrate = [bodySpacingClassName]
         for (const cssClass of cssClassesNeedToMigrate) {
           if (removedBody.classList.contains(cssClass)) addedBody.classList.add(cssClass)
         }
@@ -182,6 +183,7 @@ export function persistGitakoElements(SideBarElement: HTMLElement, logoElement: 
         if (removedBody.contains(SideBarElement)) removedBody.removeChild(SideBarElement)
         if (!addedBody.contains(logoElement)) addedBody.appendChild(logoElement)
         if (removedBody.contains(logoElement)) removedBody.removeChild(logoElement)
+        addedBody.dataset.withGitakoSpacing = removedBody.dataset.withGitakoSpacing
       }
     }
 


### PR DESCRIPTION
Before: 
![before](https://user-images.githubusercontent.com/10359255/177385660-91d0eb45-9021-48b5-a3d5-cf173a6d9db4.gif)


This issue is reproducible on my Chrome stable 103.0.5060.53 and Edge beta 103.0.1264.45 (empty profile with no other extensions enabled), in particular when my account is logged in. 

What I observed is that when page is navigated, the class list of document.body is reset and mutated by github, and so there is a moment when `.with-gitako-spacing` does not exist on document.body. This pr proposes one workaround of using dataset rather than a css class.

Another interesting observation is that `now GitHub replaces whole body element after redirecting using turbo` seems not true in my case; instead, it just replaces the whole class list rather than the whole body element.

After:
![after-min](https://user-images.githubusercontent.com/10359255/177386797-aeef6f5b-97e6-40a5-94fb-59d7468fe214.gif)

