### PR TITLE
fix: support older versions of Github Enterprise

### DIFF
--- a/src/platforms/GitHub/index.ts
+++ b/src/platforms/GitHub/index.ts
@@ -75,7 +75,7 @@ export function isEnterprise() {
        * </a>
        */
       $(
-        'a.Header-link[aria-label="Homepage Enterprise"]',
+        'a.Header-link[aria-label^="Homepage"]',
         e => e.textContent?.trim() === 'Enterprise',
       )) ||
     false

--- a/src/platforms/GitHub/index.ts
+++ b/src/platforms/GitHub/index.ts
@@ -75,7 +75,10 @@ export function isEnterprise() {
        * </a>
        */
       $(
-        'a.Header-link[aria-label^="Homepage"]',
+        [
+          'a.Header-link[aria-label="Homepage Enterprise"]',
+          'a.Header-link[aria-label="Homepage"]', // legacy support
+        ].join(),
         e => e.textContent?.trim() === 'Enterprise',
       )) ||
     false


### PR DESCRIPTION
在较旧的 Github Enterprise 版本中 Github 头部标题仅包含 `Homepage` 关键字，考虑增加兼容性，例如 `Version 2.17.5`

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/1013615/233836562-bed08602-2154-4ca5-8b26-0a66bebd525a.png">
