### PR TITLE
fix: sidebar navigation reset for github

### DIFF
--- a/src/platforms/GitHub/DOMHelper.ts
+++ b/src/platforms/GitHub/DOMHelper.ts
@@ -57,7 +57,7 @@ export function isInRepoPage() {
 }
 
 export function isInCodePage() {
-  const branchListSelector = ['#branch-select-menu', '.branch-select-menu'].join()
+  const branchListSelector = ['#branch-select-menu', '.branch-select-menu', 'button[id^=branch-picker]'].join()
   // The element may still exist in DOM for PR pages, but not visible
   return Boolean($(branchListSelector, e => e.offsetWidth > 0 && e.offsetHeight > 0))
 }


### PR DESCRIPTION
fix #279

I find that the bug #279 occurs with the github updates, maybe it upated the DOM layout. The code of Gitako to check in code page not working now.

![image](https://github.com/EnixCoda/Gitako/assets/9403654/a32253c7-0aba-425c-9bc2-066f683d72b7)

but in the specific file page the attributes are:
![image](https://github.com/EnixCoda/Gitako/assets/9403654/e8dc1f02-bad1-49a4-91e8-4562d16f0936)

Now, the sidebar will reset when visit the specific file like this
![old-sidebar-reset](https://github.com/EnixCoda/Gitako/assets/9403654/93128822-643f-4dea-80b0-07feb8e46a9d)

apply my commit and it works now
![new-sidebar-reset](https://github.com/EnixCoda/Gitako/assets/9403654/2c662b13-2234-4eef-9fa1-9b85bd5a31ec)
