### PR TITLE
feat: Support for GitHub Enterprise 3.12 and later versions

### DIFF
--- a/src/platforms/GitHub/index.ts
+++ b/src/platforms/GitHub/index.ts
@@ -66,20 +66,27 @@ export function processTree(tree: TreeNode[]): TreeNode {
 }
 
 export function isEnterprise() {
+  if (window.location.host === 'github.com') return false
+
   return (
-    (window.location.host !== 'github.com' &&
-      /**
-       * <a class="Header-link " href="https://host.com/" data-hotkey="g d" aria-label="Homepage Enterprise">
-       *   <span>Enterprise</span>
-       * </a>
-       */
-      $(
-        [
-          'a.Header-link[aria-label="Homepage Enterprise"]',
-          'a.Header-link[aria-label="Homepage"]', // legacy support
-        ].join(),
-        e => e.textContent?.trim() === 'Enterprise',
-      )) ||
+    /**
+     * <a class="AppHeader-logo" href="https://host.com/" data-hotkey="g d" aria-label="Homepage Enterprise">
+     *   <svg></svg>
+     * </a>
+     */
+    $('a.AppHeader-logo[aria-label="Homepage Enterprise"]') !== null ||
+    /**
+     * <a class="Header-link " href="https://host.com/" data-hotkey="g d" aria-label="Homepage Enterprise">
+     *   <span>Enterprise</span>
+     * </a>
+     */
+    $(
+      [
+        'a.Header-link[aria-label="Homepage Enterprise"]',
+        'a.Header-link[aria-label="Homepage"]', // legacy support
+      ].join(),
+      e => e.textContent?.trim() === 'Enterprise',
+    ) ||
     false
   )
 }


### PR DESCRIPTION
<img width="1127" alt="스크린샷 2024-03-28 오전 11 37 27" src="https://github.com/EnixCoda/Gitako/assets/42956032/4fd3fb35-97ba-4bd2-ba36-463bfd987ec9">

The "Enterprise" text in the header is missing, so change it to detect it as a logo