### PR TITLE
fix(GitHub): 优化仓库页面识别逻辑,修复github不显示图标

### DIFF
--- a/src/platforms/GitHub/DOMHelper.ts
+++ b/src/platforms/GitHub/DOMHelper.ts
@@ -114,6 +114,12 @@ export function resolveMeta(): Partial<MetaData> {
 export function isInRepoPage() {
   const repoHeadSelector = '.repohead'
   const authorNameSelector = '.author[itemprop="author"]'
+  const repoMetaSelector = [
+    'meta[name="octolytics-dimension-repository_nwo"]',
+    'meta[name="octolytics-dimension-repository_id"]',
+  ].join()
+  if (document.querySelector(repoMetaSelector)) return true
+
   return Boolean(
     document.querySelector(
       [


### PR DESCRIPTION
- 增加通过 meta 标签判断是否为仓库页面的逻辑
- 使用 octolytics-dimension-repository_nwo 和 repository_id 作为判断条件
- 保持原有的 DOM 查询方式作为辅助判断
- 提升仓库页面识别的准确性和鲁棒性